### PR TITLE
Crashes in samsung device 

### DIFF
--- a/PolyPickerDemo/pp/src/main/java/nl/changer/polypicker/CwacCameraFragment.java
+++ b/PolyPickerDemo/pp/src/main/java/nl/changer/polypicker/CwacCameraFragment.java
@@ -61,6 +61,9 @@ public class CwacCameraFragment extends CameraFragment {
 
     // initialize with default config.
     private static Config mConfig;
+    
+     String deviceMan = android.os.Build.MANUFACTURER;
+     String deviceName = android.os.Build.MODEL;
 
     @Override
     public void onCreate(Bundle state) {
@@ -137,7 +140,9 @@ public class CwacCameraFragment extends CameraFragment {
 
         PictureTransaction pictureTransaction = new PictureTransaction(getHost());
         pictureTransaction.needBitmap(true);
-        pictureTransaction.flashMode(flashMode);
+        if (!deviceMan.equalsIgnoreCase("samsung")) {
+            pictureTransaction.flashMode(flashMode);
+        }
         super.takePicture(pictureTransaction);
     }
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-poly-picker
+PolyPicker
 ===========
 
 Android library project for selecting/capturing multiple images from the device.


### PR DESCRIPTION
I made a workaround which helps to avoid crash in samsung devices while using camera with flash . its just crack work around . But it helped me to continue these lib with my application . 
WORK AROUND SUMMARY : it ill avoid flash while taking photos with samsung device in low light which helps to avoid almost 99% of issue with samsung device . i know its not a big solution but helpful i think