### PR TITLE
Fix commonsware repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ dependencies {
 repositories {
     // for downloading polypicker dependency cwac-camera
     maven {
-        url "https://repo.commonsware.com.s3.amazonaws.com"
+        url "https://s3.amazonaws.com/repo.commonsware.com"
     }
 
     // for downloading poly-picker now we are using jitpack.


### PR DESCRIPTION
The old URL is no longer delivering a valid TLS certificate.